### PR TITLE
fix: use React.JSX namespace for React 19 type compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -17,7 +17,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["package.json"],
+        "assets": ["package.json", "package-lock.json"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # next-lazy-hydration-on-scroll
 
-⚠️ **Pages Directory Only** - For Next.js App Directory better use [built-in streaming](https://nextjs.org/learn/dashboard-app/streaming).
+Hydrate Next.js components when they scroll into view instead of all at once on load.
 
-Optimize Next.js app performance by lazy loading and hydrating components when they enter the viewport.
+The HTML is still server-rendered, so the page looks and indexes the same. Only the JavaScript is deferred — which cuts hydration work off the critical path and lowers TBT.
 
-- ⚡️ Lower Total Blocking Time (TBT)
-- 📦 Smaller Bundle Size
-- 🚀 Improved Performance
+> **Pages Router only.** On the App Router, use Server Components and [streaming](https://nextjs.org/docs/app/guides/streaming) instead. Requires React 18+.
 
-## Installation
+## Still relevant in 2026
+
+Plenty of production apps are still on the Pages Router. It ships in Next.js 16, is not deprecated, and has [its own actively maintained docs](https://nextjs.org/docs/pages/getting-started).
+
+Migration is also [incremental by design](https://nextjs.org/docs/app/guides/migrating/app-router-migration) — `app/` and `pages/` run side by side, page by page — so codebases sit half-migrated for a long time, and the `pages/` half never gets Server Components. Those routes hydrate the whole tree on every load. That's what this fixes, without a rewrite.
+
+## Install
 
 ```bash
 npm install next-lazy-hydration-on-scroll
-# or
-yarn add next-lazy-hydration-on-scroll
-# or
-pnpm add next-lazy-hydration-on-scroll
 ```
 
 ## Usage
@@ -23,88 +23,65 @@ pnpm add next-lazy-hydration-on-scroll
 ```tsx
 import { lazyHydrate } from 'next-lazy-hydration-on-scroll'
 
-const LazyComponent = lazyHydrate(() => import('./components/HeavyComponent'), {
-  LoadingComponent: () => <div>Loading...</div>, // Optional
-  wrapperElement: 'div', // Optional, defaults to 'section'
-})
+const HeavyComponent = lazyHydrate(() => import('./components/HeavyComponent'))
 
 export default function Page() {
   return (
     <div>
-      <header>Always hydrated</header>
-      <LazyComponent wrapperProps={{ className: 'my-wrapper', id: 'lazy-component' }} /> {/* Hydrates when scrolled into view */}
+      <header>Hydrated immediately</header>
+      <HeavyComponent /> {/* hydrates on scroll */}
     </div>
   )
 }
 ```
 
-## Options
-
-| Option             | Type                          | Default       | Description                                             |
-| ------------------ | ----------------------------- | ------------- | ------------------------------------------------------- |
-| `rootMargin`       | `string`                      | `'0px 250px'` | Margin around the root element for IntersectionObserver |
-| `LoadingComponent` | `ComponentType`               | `undefined`   | Component to show while loading                         |
-| `wrapperElement`   | `keyof JSX.IntrinsicElements` | `'section'`   | HTML element to wrap the component                      |
-
-## Component Props
-
-| Prop           | Type                  | Description                          |
-| -------------- | --------------------- | ------------------------------------ |
-| `wrapperProps` | `Record<string, any>` | Props to pass to the wrapper element |
-
-## How It Works
-
-1. Server renders full HTML content
-2. Components remain static until scrolled into view
-3. When component enters viewport:
-   - JavaScript is loaded
-   - Component is hydrated
-   - Interactivity is enabled
-
-## Implementation Requirements
-
-- Keep components in separate files
-- Avoid barrel files (index.ts that re-exports components)
-- Import components directly:
+With options:
 
 ```tsx
-// ✅ Correct
-import { ComponentA } from './components/ComponentA'
-
-// ❌ Avoid
-// components/index.ts with re-exports
+const HeavyComponent = lazyHydrate(() => import('./components/HeavyComponent'), {
+  rootMargin: '0px 400px',
+  wrapperElement: 'div',
+  LoadingComponent: () => <div>Loading…</div>,
+})
 ```
 
-## Browser Support
+## Options
 
-Works in all modern browsers supporting IntersectionObserver (IE11+ with polyfill).
+| Option             | Type                                | Default       | Description                                            |
+| ------------------ | ----------------------------------- | ------------- | ------------------------------------------------------ |
+| `rootMargin`       | `string`                            | `'0px 250px'` | How early to hydrate, relative to the viewport         |
+| `wrapperElement`   | `keyof React.JSX.IntrinsicElements` | `'section'`   | Tag used for the wrapper element                       |
+| `LoadingComponent` | `ComponentType`                     | `undefined`   | Shown while the chunk loads                            |
 
-## Notes
+Props are forwarded to your component, except `wrapperProps`, which is spread onto the wrapper:
 
-- SEO friendly - content is pre-rendered
-- Components are wrapped in customizable elements (default: `<section>`) for stable viewport detection
-- Works with Next.js 12 and above
+```tsx
+<HeavyComponent title="forwarded" wrapperProps={{ className: 'wrapper' }} />
+```
 
-## FAQ
+## Why not `next/dynamic`
 
-### Q: Does it affect SEO?
+`next/dynamic` splits the chunk, but the component is still part of the tree, so its JavaScript is needed to hydrate the page. Using `ssr: false` avoids that but drops the server-rendered HTML.
 
-A: No - all content is pre-rendered and visible to search engines.
+`lazyHydrate` keeps the HTML *and* keeps the chunk off the initial path.
 
-### Q: What's the browser support?
+## Gotchas
 
-A: All modern browsers (IE11+ with polyfill).
+- **Give the component its own file.** Barrel files (`index.ts` re-exports) pull siblings into the same chunk and defeat the split.
+- **The wrapper is a real element.** Parent flex/grid rules see it, not your component. Adjust with `wrapperElement` / `wrapperProps`, or `display: contents`.
+- **Nothing runs before hydration.** No effects, no event handlers — so no analytics impressions inside a lazy component.
+- **Skip it above the fold.** Visible components hydrate right away anyway.
 
-### Q: Why are components wrapped in an element?
+## How it works
 
-A: For two reasons: to provide a stable element for IntersectionObserver tracking, and to handle hydration mismatches with `suppressHydrationWarning`.
+The wrapper renders empty on the client with `dangerouslySetInnerHTML` and `suppressHydrationWarning`, so React leaves the server HTML alone and never descends into the subtree. An `IntersectionObserver` then loads and hydrates the component as it nears the viewport. Without `IntersectionObserver`, it hydrates immediately.
 
-### Q: Can I customize the wrapper element?
+## Further reading
 
-A: Yes - use the `wrapperElement` option to specify any valid HTML element (e.g., 'div', 'article') and pass props to it using the `wrapperProps` prop.
+- [New Suspense SSR Architecture in React 18](https://github.com/reactwg/react-18/discussions/37) — why hydration is one blocking pass
+- [Rendering on the Web](https://web.dev/articles/rendering-on-the-web) — hydration's cost to TBT and INP
+- [Islands Architecture](https://jasonformat.com/islands-architecture/) — the broader pattern
 
-### Q: Why is dangerouslySetInnerHTML used?
+## License
 
-A: It prevents React from hydrating down the component tree, allowing to preserve server-rendered content while controlling when hydration occurs.
-
-[View Demo](https://next-lazy-hydration-on-scroll.wrotek.dev/) | [GitHub Repository](https://github.com/woywro/next-lazy-hydration-on-scroll)
+MIT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-lazy-hydration-on-scroll",
-  "version": "1.1.7",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "next-lazy-hydration-on-scroll",
-      "version": "1.1.7",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
@@ -9229,21 +9229,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/semantic-release/node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "build": "tsup src/index.tsx --format esm,cjs --dts --external react",
-    "dev": "tsup src/index.ts --format esm,cjs --watch --dts --external react",
+    "dev": "tsup src/index.tsx --format esm,cjs --watch --dts --external react",
     "clean": "rm -rf node_modules && rm -rf dist",
     "prepublishOnly": "npm run build"
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,16 +1,17 @@
 import dynamic from 'next/dynamic'
 import React, { ComponentType, FC, useEffect, useRef, useState } from 'react'
 
+type WrapperTag = keyof React.JSX.IntrinsicElements
+
 type LazyHydrateHydrateOptions = {
   rootMargin?: string
   LoadingComponent?: ComponentType
-  wrapperElement?: keyof JSX.IntrinsicElements
+  wrapperElement?: WrapperTag
 }
 
 type HydrateOptions = {
   rootMargin: string
-  LoadingComponent?: ComponentType
-  wrapperElement?: keyof JSX.IntrinsicElements
+  wrapperElement?: WrapperTag
 }
 
 type ComponentProps = {
@@ -24,7 +25,7 @@ const hydrate = <P extends ComponentProps>(
 ): FC<P> => {
   const { rootMargin, wrapperElement = 'section' } = options
   const Hydration: FC<P> = ({ wrapperProps = {}, ...props }) => {
-    const rootRef = useRef<HTMLDivElement>(null)
+    const rootRef = useRef<HTMLElement>(null)
     const [isHydrated, setIsHydrated] = useState(false)
 
     const initIntersectionObserver = (rootMargin: string): (() => void) | undefined => {
@@ -66,8 +67,8 @@ const hydrate = <P extends ComponentProps>(
     }
     return (
       <WrapperElement
-        ref={rootRef}
         {...wrapperProps}
+        ref={rootRef}
         dangerouslySetInnerHTML={{ __html: '' }}
         suppressHydrationWarning
       />


### PR DESCRIPTION
  The published .d.ts referenced the global JSX namespace, which is removed
  in @types/react@19 (TS2503). Also fixes wrapperProps clobbering the
  observer ref, and the dev script pointing at a nonexistent src/index.ts.
